### PR TITLE
User defined ESP32 BLE Device name

### DIFF
--- a/src/BlynkSimpleEsp32_BLE.h
+++ b/src/BlynkSimpleEsp32_BLE.h
@@ -15,6 +15,11 @@
 #define BLYNK_INFO_CONNECTION "Esp32_BLE"
 #endif
 
+#ifndef BLYNK_ESP32_BLE_DEVICENAME
+#define BLYNK_ESP32_BLE_DEVICENAME "Blynk"
+#endif
+
+
 #define BLYNK_SEND_ATOMIC
 #define BLYNK_SEND_CHUNK 20
 //#define BLYNK_SEND_THROTTLE 20
@@ -47,7 +52,7 @@ public:
 
     void begin() {
         // Create the BLE Device
-        BLEDevice::init("Blynk");
+        BLEDevice::init(BLYNK_ESP32_BLE_DEVICENAME);
 
         // Create the BLE Server
         pServer = BLEDevice::createServer();

--- a/src/BlynkSimpleEsp32_BLE.h
+++ b/src/BlynkSimpleEsp32_BLE.h
@@ -15,8 +15,8 @@
 #define BLYNK_INFO_CONNECTION "Esp32_BLE"
 #endif
 
-#ifndef BLYNK_ESP32_BLE_DEVICENAME
-#define BLYNK_ESP32_BLE_DEVICENAME "Blynk"
+#ifndef BLE_DEVICE_NAME
+#define BLE_DEVICE_NAME "Blynk"
 #endif
 
 
@@ -52,7 +52,7 @@ public:
 
     void begin() {
         // Create the BLE Device
-        BLEDevice::init(BLYNK_ESP32_BLE_DEVICENAME);
+        BLEDevice::init(BLE_DEVICE_NAME);
 
         // Create the BLE Server
         pServer = BLEDevice::createServer();


### PR DESCRIPTION
Add possibility to define the device name of the ESP32 BLE device

### Description
Add the possibility to have more then one ESP32 module in the same space: add the possibility to change the name of the ESP32 BLE device, so that users know which module they have to connect to. Especially important during workshop with multiple persons & mobile phones.

### Issues Resolved
https://community.blynk.cc/t/esp32-ble-devicename/23884
