### PR TITLE
Flushing buffer in direct mode (BLE)

### DIFF
--- a/src/Blynk/BlynkProtocol.h
+++ b/src/Blynk/BlynkProtocol.h
@@ -78,9 +78,13 @@ public:
 private:
 
     void internalReconnect() {
+#ifdef BLYNK_USE_DIRECT_CONNECT
+        conn.connect(); // forces flushing the buffer to resync
+#else
         state = CONNECTING;
         conn.disconnect();
         BlynkOnDisconnected();
+#endif
     }
 
     int readHeader(BlynkHeader& hdr);


### PR DESCRIPTION
When running Blynk in direct mode (using Bluetooth/BLE), the connection can stop working after "Packet too big" or "Invalid header type". The cause is the loss of one or more bytes, which makes the Blynk protocol get out of sync, resulting in a connection being closed.
However, it is not necessary to stop the connection, it just needs to resync. Because the Blynk protocol misses sync bytes, it should be done in another way. In this solution, it makes use of the fact that Blynk on BT/BLE is sending its bytes in block, starting with the header. So, in case the systen is no longer synced, we just need to flush the buffer to get it in sync again. Using this fix, the stability of BLE in Blynk increases a lot. Because conn.flush() doesn't exist, we make use of the fact that conn.connect() is basically executing a buffer flush.

### Description
When some bytes are missing in the Blynk data stream when running in direct mode (BT/BLE), the protocol will try to resync instead of stopping the connection by flushing the buffer.

### Issues Resolved
Improvement of BLE stability in case of lost bytes